### PR TITLE
Update 'install' option kernel cmdline for v19.x

### DIFF
--- a/gfxboot-turnkey/isolinux/menu.cfg
+++ b/gfxboot-turnkey/isolinux/menu.cfg
@@ -2,7 +2,7 @@ default install
 label install
   menu label Install to hard disk
   kernel /live/vmlinuz
-  append boot=live initrd=/live/initrd.gz root=/dev/ram rw showmounts di-live single noinithooks net.ifnames=0 --
+  append boot=live initrd=/live/initrd.gz root=/dev/ram rw showmounts tkl-installer single noinithooks net.ifnames=0 --
 label live
   menu label Try without installing (Live CD demo mode)
   kernel /live/vmlinuz


### PR DESCRIPTION
Replace `di-live` with `tkl-installer` when user selects "install" in ISO boot menu.