### PR TITLE
Update kernel cmdline so live-boot uses our intefaces file

### DIFF
--- a/gfxboot-turnkey/isolinux/menu.cfg
+++ b/gfxboot-turnkey/isolinux/menu.cfg
@@ -2,11 +2,11 @@ default install
 label install
   menu label Install to hard disk
   kernel /live/vmlinuz
-  append boot=live initrd=/live/initrd.gz root=/dev/ram rw showmounts tkl-installer single noinithooks net.ifnames=0 --
+  append boot=live initrd=/live/initrd.gz ip=frommedia root=/dev/ram rw showmounts tkl-installer single noinithooks net.ifnames=0 --
 label live
   menu label Try without installing (Live CD demo mode)
   kernel /live/vmlinuz
-  append boot=live initrd=/live/initrd.gz root=/dev/ram rw showmounts net.ifnames=0 --
+  append boot=live initrd=/live/initrd.gz ip=frommedia root=/dev/ram rw showmounts net.ifnames=0 --
 label localboot
   menu label Attempt to boot from first hard disk
   com32 chain.c32


### PR DESCRIPTION
By default Debian's live-boot generates a default interfaces file, but we actually want it to use the one we provide. This overrides the default behavior by adding 'ip=frommedia'.